### PR TITLE
Add `createRenameTableMigration` to rename a history connected table.

### DIFF
--- a/src/history-utils/README.md
+++ b/src/history-utils/README.md
@@ -213,3 +213,36 @@ exports.down = async function (knex) {
   `);
 };
 ```
+
+## Renaming history-connected tables
+
+Create a migration file `20200613163000_rename_car_to_vehicle_test.js`:
+
+```js
+const { createRenameTableMigration } = require("@ailo/knex-utils");
+
+const renameCarToVehicleMigration = createRenameTableMigration({
+  oldTableName: "car",
+  oldTypeName: "car_type",
+  newTableName: "vehicle",
+  newTypeName: "vehicle_type",
+});
+
+exports.up = async function (knex) {
+  await renameCarToVehicleMigration.up(knex);
+  // Unfortunately there seems to be no way to rename constraints
+  // - renaming constraints doesn't work on typed tables
+  // - dropping the constraint and recreating it after the rename didn't seem
+  //   to work either (need further investigation)
+  // await knex.raw(`
+  //   ALTER TABLE vehicle RENAME CONSTRAINT car_pkey TO vehicle_pkey;
+  // `);
+};
+
+exports.down = async function (knex) {
+  //   await knex.raw(`
+  //   ALTER TABLE vehicle RENAME CONSTRAINT vehicle_pkey TO car_pkey;
+  // `);
+  await renameCarToVehicleMigration.down(knex);
+};
+```

--- a/src/history-utils/createRenameTableMigration.ts
+++ b/src/history-utils/createRenameTableMigration.ts
@@ -1,0 +1,72 @@
+import Knex from "knex";
+
+export interface CreateRenameTableMigrationOptions {
+  oldTableName: string;
+  oldTypeName: string;
+  newTableName: string;
+  newTypeName: string;
+  /**
+   * @default "public"
+   */
+  schema?: string;
+}
+
+export function createRenameTableMigration(
+  options: CreateRenameTableMigrationOptions
+): Knex.Migration {
+  return {
+    up: createRenameTableMigrationUp(options),
+    down: createRenameTableMigrationDown(options),
+  };
+}
+
+function createRenameTableMigrationUp({
+  oldTableName,
+  oldTypeName,
+  newTableName,
+  newTypeName,
+  schema = "public",
+}: CreateRenameTableMigrationOptions) {
+  return async (knex: Knex) => {
+    await knex.schema.raw(`
+      ALTER TYPE ${schema}.${oldTypeName} RENAME TO ${newTypeName}
+    `);
+    await knex.schema.raw(`
+      ALTER TABLE ${schema}.${oldTableName} RENAME TO ${newTableName}
+    `);
+    await knex.schema.raw(`
+      ALTER INDEX ${oldTableName}_sys_period RENAME TO ${newTableName}_sys_period
+    `);
+    await knex.schema.raw(`
+      ALTER TABLE ${schema}.${oldTableName}_history RENAME TO ${newTableName}_history
+    `);
+
+    await knex.schema.raw(`
+      DROP TRIGGER versioning_trigger ON ${schema}.${newTableName};
+      CREATE TRIGGER versioning_trigger
+        BEFORE INSERT OR UPDATE OR DELETE ON ${schema}.${newTableName}
+        FOR EACH ROW EXECUTE PROCEDURE versioning(
+          'sys_period', '${schema}.${newTableName}_history', true
+        );
+    `);
+    await knex.schema.raw(`
+      ALTER INDEX ${oldTableName}_history_sys_period RENAME TO ${newTableName}_history_sys_period 
+    `);
+  };
+}
+
+function createRenameTableMigrationDown({
+  oldTableName,
+  oldTypeName,
+  newTableName,
+  newTypeName,
+  schema = "public",
+}: CreateRenameTableMigrationOptions) {
+  return createRenameTableMigrationUp({
+    newTableName: oldTableName,
+    newTypeName: oldTypeName,
+    oldTableName: newTableName,
+    oldTypeName: newTypeName,
+    schema,
+  });
+}

--- a/src/history-utils/index.ts
+++ b/src/history-utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./createHistoryMigration";
 export * from "./createHistoryVersioningMigration";
+export * from "./createRenameTableMigration";


### PR DESCRIPTION
Add `createRenameTableMigration` to rename a history connected table.

It:
- renames the type
- renames the tables
- recreates the `versioning_trigger` constraint

It doesn't rename any existing indexes (apart from the index on `sys_period` which was created by `createHistoryMigration`).