### PR TITLE
perf: disable fysnc in postgres container for tests

### DIFF
--- a/bin/local-db.sh
+++ b/bin/local-db.sh
@@ -69,7 +69,8 @@ function launch_container() {
                     -e POSTGRES_USER="${DB_USER}"           \
                     -e POSTGRES_PASSWORD="${DB_PASSWORD}"   \
                     -p 5432                                 \
-                    -d postgres:12
+                    -d postgres:12                          \
+                    -c fsync=off
     DB_PORT=$(docker port "${DB_NAME}${DOCKER_SUFFIX}" 5432 | cut -d':' -f2)
 
     echo -e "\nTo run node app/tests with local db, use following env vars:"


### PR DESCRIPTION
Is it possible to speed up our tests somehow? Maybe disabling fsync might help?

When I did that in the pm service, `resetKnex` went from ~150-200ms to ~35-55ms. If this is okay, we can consider trying it in our `docker-compose.ci.yml` files as well?

Edit: looks like pm service's `docker-compose.ci.yml` already disabled it.

[fsync docs](https://www.postgresql.org/docs/9.5/runtime-config-wal.html#:~:text=fsync%20(boolean))

